### PR TITLE
Allow variable argument lists in #defines of ILog.h

### DIFF
--- a/src/ILog.h
+++ b/src/ILog.h
@@ -41,22 +41,22 @@ extern ILog const * _log;
 #undef module_name
 #define module_name 0
 
-#define Message(s, ...) _Message(0, module_name, s , ##__VA_ARGS__)
-#define Warning(s, ...) _Message(1, module_name, s , ##__VA_ARGS__)
-#define Error(s, ...) _Message(2, module_name, s , ##__VA_ARGS__)
-#define Green(s, ...) _Message(3, module_name, s , ##__VA_ARGS__)
-#define Progress(s, ...) _Message(99, "Progress", s , ##__VA_ARGS__)
+#define Message(s, ...) _Message(0, module_name, s __VA_OPT__(,) __VA_ARGS__)
+#define Warning(s, ...) _Message(1, module_name, s __VA_OPT__(,) __VA_ARGS__)
+#define Error(s, ...) _Message(2, module_name, s __VA_OPT__(,) __VA_ARGS__)
+#define Green(s, ...) _Message(3, module_name, s __VA_OPT__(,) __VA_ARGS__)
+#define Progress(s, ...) _Message(99, "Progress", s __VA_OPT__(,) __VA_ARGS__)
 
 //#define VERBOSE
 
 #ifdef VERBOSE
-#define Verbose(s, ...) _Message(0, module_name, s, ##__VA_ARGS__)
+#define Verbose(s, ...) _Message(0, module_name, s __VA_OPT__(,) __VA_ARGS__)
 #else
 #define Verbose(s, ...) null
 #endif
 
 #ifdef DEBUGLOG
-#define Debug(lvl, s, ...) _Debug(lvl, module_name, s, ##__VA_ARGS__)
+#define Debug(lvl, s, ...) _Debug(lvl, module_name, s __VA_OPT__(,) __VA_ARGS__)
 #else
 #define Debug(lvl, s, ...) null
 #endif


### PR DESCRIPTION
Compare https://gcc.gnu.org/onlinedocs/cpp/Variadic-Macros.html .
 
Only tried on --version, yet, and this seems to just work nicely.